### PR TITLE
feat(vulnerability): implement two-phase OSV.dev scan with full vuln detail fetching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SBOM Viewer is a Blazor WebAssembly (WASM) client-side app that dynamically parses and displays SPDX 2.2, CycloneDX 1.6, and CycloneDX 1.7 SBOM JSON files in the browser. The UI is generated dynamically from the uploaded JSON structure — no static model classes or hardcoded viewers. All processing happens client-side — there is no backend API. Deployed as an Azure Static Web App at sbomviewer.com.
 
-The app includes a **vulnerability scanning** feature that checks all SBOM components against the [OSV.dev](https://osv.dev) (Open Source Vulnerabilities) database. Scanning is user-initiated and runs entirely client-side via the OSV.dev batch API.
+The app includes a **vulnerability scanning** feature that checks all SBOM components against the [OSV.dev](https://osv.dev) (Open Source Vulnerabilities) database. Scanning is user-initiated and runs entirely client-side via the OSV.dev batch and detail APIs.
 
 ## Build & Run Commands
 
@@ -68,9 +68,9 @@ SBOMViewer.slnx
 │       │   ├── SbomState.cs            # Singleton state: JsonDocument, SchemaNode, format, filename
 │       │   ├── SbomFormatDetector.cs   # Format detection + lightweight required-field validation
 │       │   ├── SchemaService.cs        # Builds SchemaNode tree from uploaded JSON, applies render hints
-│       │   ├── ChatState.cs            # Singleton state: vuln results, scan progress, chat messages
+│       │   ├── ChatState.cs            # Singleton state: vuln results, scan progress, warnings, chat messages
 │       │   ├── PackageExtractor.cs     # Extracts packages from SBOM JSON (CycloneDX + SPDX)
-│       │   └── VulnerabilityService.cs # OSV.dev batch API client for vulnerability scanning
+│       │   └── VulnerabilityService.cs # OSV.dev two-phase scan: batch query + per-vuln detail fetch
 │       ├── Models/
 │       │   ├── SbomFormat.cs           # Enum: CycloneDX_1_6, CycloneDX_1_7, SPDX_2_2
 │       │   ├── SchemaNode.cs           # SchemaNode, SchemaNodeType, RenderHint
@@ -122,7 +122,7 @@ The app version lives in `Directory.Build.props` at the repo root and is inherit
 5. **SchemaService.BuildFromJson** — builds a `SchemaNode` tree from the JSON structure, applies render hints
 6. **SbomState** — singleton holding `JsonDocument`, `SchemaNode`, detected format, and filename; notifies subscribers via `OnChange`
 7. **DynamicSbomViewer** → **DynamicSection** → **DynamicObject** — recursive components that walk `JsonElement` + `SchemaNode` to render Fluent UI
-8. **Vulnerability scan** (user-initiated) — **PackageExtractor** extracts packages → **VulnerabilityService** queries OSV.dev batch API → **ChatState** stores results → **VulnerabilitySummary** renders severity breakdown and affected packages
+8. **Vulnerability scan** (user-initiated) — **PackageExtractor** extracts packages → **VulnerabilityService** queries OSV.dev in two phases (batch to collect IDs, then per-vuln detail fetch) → **ChatState** stores results → **VulnerabilitySummary** renders severity breakdown and affected packages
 
 ### Dynamic Rendering Pipeline
 
@@ -134,14 +134,18 @@ The UI is generated dynamically from the uploaded JSON — no static C# model cl
 
 ### Vulnerability Scanning
 
-User-initiated vulnerability scanning via the [OSV.dev](https://osv.dev) batch API — all processing is client-side:
+User-initiated vulnerability scanning via the [OSV.dev](https://osv.dev) API — all processing is client-side:
 
 - **PackageExtractor** — extracts `PackageInfo` (name, version, ecosystem, purl) from the SBOM JSON. CycloneDX uses the `components` array + purl; SPDX uses the `packages` array + `externalRefs`
-- **VulnerabilityService** — batches packages in groups of 100, POSTs to `https://api.osv.dev/v1/querybatch`, parses responses into `VulnerabilityResult` with severity, CVSS score, and fix version
-- **ChatState** — singleton holding scan results, progress, and error state. `ClearVulnerabilities()` is called on new file upload to reset stale data
-- **DynamicSbomViewer** — Vulnerabilities accordion section with "Scan for Vulnerabilities" button, progress overlay, count badge, and hover info popover explaining the OSV.dev integration
-- **VulnerabilitySummary** — severity breakdown badges (Critical/High/Medium/Low/Unknown), searchable list of affected packages, expandable CVE details with links to OSV.dev
-- **VulnerabilityBadge** — colored badge component used for severity counts
+- **VulnerabilityService** — two-phase scan:
+  - **Phase 1**: batches packages in groups of 100, POSTs to `https://api.osv.dev/v1/querybatch` to collect vuln IDs per package
+  - **Phase 2**: fetches full details for each unique vuln ID via `GET https://api.osv.dev/v1/vulns/{id}` (up to 5 concurrent requests), parses complete severity, CVSS score, summary, and fix version
+  - Hard caps prevent abuse: max **500 packages** scanned, max **200 unique vuln detail fetches** per scan. Exceeding either cap fires `onWarning` and surfaces a warning banner in the UI
+  - Severity is resolved in priority order: `database_specific.severity` → `database_specific.cvss.score` → `ecosystem_specific.severity` → `severity[].score`. `"MODERATE"` (GitHub Advisory DB) is normalised to `"MEDIUM"`
+- **ChatState** — singleton holding scan results, progress, warnings, and error state. `ClearVulnerabilities()` is called on new file upload to reset stale data. `ScanWarnings` accumulates non-fatal cap/truncation notices
+- **DynamicSbomViewer** — Vulnerabilities accordion section with "Scan for Vulnerabilities" button, progress overlay (tracks vuln detail fetches), count badge, warning banners, and hover info popover
+- **VulnerabilitySummary** — top-level severity breakdown badges, searchable list of affected packages with per-severity badge breakdown per package (not a single combined badge), expandable CVE details with links to OSV.dev
+- **VulnerabilityBadge** — colored severity badge; MEDIUM uses dark text (`#1a1a1a`) on amber background for legibility
 
 ### Key Models
 
@@ -185,7 +189,7 @@ Uses **Microsoft.FluentUI.AspNetCore.Components** (v4.13.2) for all UI component
 - **UI components**: Use Fluent UI (`FluentCard`, `FluentAccordion`, `FluentSearch`, `FluentBadge`, etc.). Reference icons via the `Icons` alias from `_Imports.razor`.
 - **Dynamic rendering**: All three viewer components (`DynamicSbomViewer`, `DynamicSection`, `DynamicObject`) work with `JsonElement` + `SchemaNode` — no format-specific logic.
 - **File uploads**: Max 20MB, `.json` only. Auto-detects format from JSON content.
-- **Vulnerability scanning**: User-initiated via OSV.dev batch API. `PackageExtractor` extracts packages, `VulnerabilityService` queries OSV.dev, results stored in `ChatState`. Vulnerability data is cleared on new file upload via `ChatState.ClearVulnerabilities()`.
+- **Vulnerability scanning**: User-initiated two-phase scan. Phase 1: `POST /v1/querybatch` collects vuln IDs per package. Phase 2: `GET /v1/vulns/{id}` fetches full details for each unique ID (max 5 concurrent). Hard caps: 500 packages, 200 vuln detail fetches. Results and warnings stored in `ChatState`. Cleared on new file upload via `ChatState.ClearVulnerabilities()`.
 - **Accordion item counts**: Array sections show item count as a `FluentBadge` with accent fill. Vulnerabilities section shows count with red badge (`#d32f2f`).
 - **E2E tests**: Use NUnit + Playwright (`PageTest` base class). Tests are black-box — no project reference to `SBOMViewer.Blazor`. Target URL is controlled via `BASE_URL` env var (default `http://localhost:5000`).
 

--- a/src/SBOMViewer.Blazor/Components/DynamicSbomViewer.razor
+++ b/src/SBOMViewer.Blazor/Components/DynamicSbomViewer.razor
@@ -92,7 +92,7 @@
                                             About Vulnerability Scanning
                                         </div>
                                         <p style="margin:0 0 0.4rem 0;">
-                                            Scans all components in this SBOM against the <strong>OSV.dev</strong> (Open Source Vulnerabilities) database.
+                                            Scans up to <strong>500 components</strong> in this SBOM against the <strong>OSV.dev</strong> (Open Source Vulnerabilities) database.
                                         </p>
                                         <p style="margin:0; color:var(--neutral-foreground-hint); font-size:0.8rem;">
                                             Results include severity ratings, CVE IDs, and available fix versions.
@@ -135,6 +135,13 @@
                         {
                             <div style="padding:0.5rem;">
                                 <FluentBadge Appearance="Appearance.Lightweight" Color="Color.Error">@ChatState.ScanError</FluentBadge>
+                            </div>
+                        }
+                        @foreach (var warning in ChatState.ScanWarnings)
+                        {
+                            <div style="padding:0.4rem 0.5rem; display:flex; align-items:center; gap:0.4rem; font-size:0.82rem; color:var(--warning-foreground, #b45309);">
+                                <FluentIcon Value="@(new Icons.Regular.Size16.Warning())" />
+                                @warning
                             </div>
                         }
                         @if (ChatState.VulnResults is null && !ChatState.IsScanning && ChatState.ScanError is null)
@@ -286,12 +293,20 @@
 
             ChatState.ScanTotal = packages.Count;
 
-            var results = await VulnService.ScanAsync(packages, (done, total) =>
-            {
-                ChatState.ScanProgress = done;
-                ChatState.NotifyStateChanged();
-                InvokeAsync(StateHasChanged);
-            });
+            var results = await VulnService.ScanAsync(
+                packages,
+                onProgress: (done, total) =>
+                {
+                    ChatState.ScanProgress = done;
+                    ChatState.ScanTotal = total;
+                    ChatState.NotifyStateChanged();
+                    InvokeAsync(StateHasChanged);
+                },
+                onWarning: msg =>
+                {
+                    ChatState.ScanWarnings.Add(msg);
+                    ChatState.NotifyStateChanged();
+                });
 
             ChatState.VulnResults = results;
             _totalVulns = results.Sum(r => r.Vulnerabilities.Count);

--- a/src/SBOMViewer.Blazor/Components/VulnerabilityBadge.razor
+++ b/src/SBOMViewer.Blazor/Components/VulnerabilityBadge.razor
@@ -4,7 +4,7 @@
 {
     <FluentBadge Appearance="Appearance.Accent"
                  BackgroundColor="@GetColor()"
-                 Color="white"
+                 Color="@GetTextColor()"
                  Style="font-size:0.75rem;">
         @Count @(Severity ?? "vuln")
     </FluentBadge>
@@ -21,5 +21,11 @@
         "MEDIUM" => "#f9a825",
         "LOW" => "#1565c0",
         _ => "#757575"
+    };
+
+    private string GetTextColor() => Severity?.ToUpperInvariant() switch
+    {
+        "MEDIUM" => "#1a1a1a",
+        _ => "white"
     };
 }

--- a/src/SBOMViewer.Blazor/Components/VulnerabilitySummary.razor
+++ b/src/SBOMViewer.Blazor/Components/VulnerabilitySummary.razor
@@ -36,8 +36,12 @@
                     <summary style="cursor:pointer; padding:0.4rem 0; display:flex; align-items:center; gap:0.5rem;">
                         <strong>@pkg.PackageName</strong>
                         <span style="color:var(--neutral-foreground-hint);">@@@pkg.PackageVersion</span>
-                        <VulnerabilityBadge Count="@pkg.Vulnerabilities.Count"
-                                            Severity="@GetHighestSeverity(pkg)" />
+                        @{ var counts = GetSeverityCounts(pkg); }
+                        @if (counts.Critical > 0) { <VulnerabilityBadge Count="@counts.Critical" Severity="CRITICAL" /> }
+                        @if (counts.High > 0)     { <VulnerabilityBadge Count="@counts.High"     Severity="HIGH" /> }
+                        @if (counts.Medium > 0)   { <VulnerabilityBadge Count="@counts.Medium"   Severity="MEDIUM" /> }
+                        @if (counts.Low > 0)      { <VulnerabilityBadge Count="@counts.Low"      Severity="LOW" /> }
+                        @if (counts.Unknown > 0)  { <VulnerabilityBadge Count="@counts.Unknown"  Severity="UNKNOWN" /> }
                     </summary>
                     <div style="padding:0.25rem 0 0.5rem 0;">
                         @foreach (var vuln in pkg.Vulnerabilities)
@@ -120,6 +124,20 @@
         return _affected.Where(r =>
             r.PackageName.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ||
             r.Vulnerabilities.Any(v => v.Id.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private record SeverityCounts(int Critical, int High, int Medium, int Low, int Unknown);
+
+    private static SeverityCounts GetSeverityCounts(VulnerabilityResult pkg)
+    {
+        var vulns = pkg.Vulnerabilities;
+        return new SeverityCounts(
+            Critical: vulns.Count(v => v.Severity == "CRITICAL"),
+            High:     vulns.Count(v => v.Severity == "HIGH"),
+            Medium:   vulns.Count(v => v.Severity == "MEDIUM"),
+            Low:      vulns.Count(v => v.Severity == "LOW"),
+            Unknown:  vulns.Count(v => v.Severity is null or "NONE" or "UNKNOWN")
+        );
     }
 
     private static string GetHighestSeverity(VulnerabilityResult pkg)

--- a/src/SBOMViewer.Blazor/Services/ChatState.cs
+++ b/src/SBOMViewer.Blazor/Services/ChatState.cs
@@ -20,6 +20,7 @@ public class ChatState
     public int ScanProgress { get; set; }
     public int ScanTotal { get; set; }
     public string? ScanError { get; set; }
+    public List<string> ScanWarnings { get; } = [];
 
     public void AddMessage(ChatMessage message)
     {
@@ -44,6 +45,7 @@ public class ChatState
         ScanProgress = 0;
         ScanTotal = 0;
         ScanError = null;
+        ScanWarnings.Clear();
         NotifyStateChanged();
     }
 
@@ -60,6 +62,7 @@ public class ChatState
         ScanProgress = 0;
         ScanTotal = 0;
         ScanError = null;
+        ScanWarnings.Clear();
         NotifyStateChanged();
     }
 

--- a/src/SBOMViewer.Blazor/Services/VulnerabilityService.cs
+++ b/src/SBOMViewer.Blazor/Services/VulnerabilityService.cs
@@ -7,28 +7,66 @@ namespace SBOMViewer.Blazor.Services;
 public class VulnerabilityService(HttpClient httpClient)
 {
     private const string OsvBatchUrl = "https://api.osv.dev/v1/querybatch";
+    private const string OsvVulnDetailUrl = "https://api.osv.dev/v1/vulns/";
     private const int BatchSize = 100;
+    private const int MaxConcurrentDetailFetches = 5;
+
+    // Hard caps to prevent a maliciously large SBOM from flooding the OSV API
+    internal const int MaxPackagesToScan = 500;
+    internal const int MaxVulnDetailFetches = 200;
 
     public async Task<List<VulnerabilityResult>> ScanAsync(
         List<PackageInfo> packages,
         Action<int, int>? onProgress = null,
+        Action<string>? onWarning = null,
         CancellationToken ct = default)
     {
-        var results = new List<VulnerabilityResult>();
-        var processed = 0;
+        // Enforce package cap
+        if (packages.Count > MaxPackagesToScan)
+        {
+            onWarning?.Invoke(
+                $"SBOM contains {packages.Count} packages. Only the first {MaxPackagesToScan} will be scanned.");
+            packages = packages.Take(MaxPackagesToScan).ToList();
+        }
+
+        // Phase 1: batch query to collect vuln IDs per package
+        var packageVulnIds = await CollectVulnIdsAsync(packages, ct);
+
+        // Phase 2: fetch full details for each unique vuln ID
+        var allVulnIds = packageVulnIds.SelectMany(x => x.VulnIds).Distinct().ToList();
+
+        if (allVulnIds.Count > MaxVulnDetailFetches)
+        {
+            onWarning?.Invoke(
+                $"{allVulnIds.Count} unique vulnerabilities found. Fetching details for the first {MaxVulnDetailFetches}.");
+            allVulnIds = allVulnIds.Take(MaxVulnDetailFetches).ToList();
+        }
+
+        var vulnDetails = await FetchVulnDetailsAsync(allVulnIds, onProgress, ct);
+
+        // Map full details back to each package
+        return packageVulnIds.Select(item => new VulnerabilityResult(
+            item.Package.Name,
+            item.Package.Version,
+            item.VulnIds
+                .Select(id => vulnDetails.TryGetValue(id, out var entry) ? entry
+                              : new VulnerabilityEntry(id, null, null, null, null))
+                .ToList()
+        )).ToList();
+    }
+
+    private async Task<List<(PackageInfo Package, List<string> VulnIds)>> CollectVulnIdsAsync(
+        List<PackageInfo> packages, CancellationToken ct)
+    {
+        var results = new List<(PackageInfo Package, List<string> VulnIds)>();
 
         for (var i = 0; i < packages.Count; i += BatchSize)
         {
             ct.ThrowIfCancellationRequested();
 
             var batch = packages.Skip(i).Take(BatchSize).ToList();
-            var batchResults = await QueryBatchAsync(batch, ct);
-            results.AddRange(batchResults);
+            results.AddRange(await QueryBatchForIdsAsync(batch, ct));
 
-            processed += batch.Count;
-            onProgress?.Invoke(processed, packages.Count);
-
-            // Small delay between batches to avoid rate limiting
             if (i + BatchSize < packages.Count)
                 await Task.Delay(200, ct);
         }
@@ -36,47 +74,44 @@ public class VulnerabilityService(HttpClient httpClient)
         return results;
     }
 
-    private async Task<List<VulnerabilityResult>> QueryBatchAsync(
+    private async Task<List<(PackageInfo Package, List<string> VulnIds)>> QueryBatchForIdsAsync(
         List<PackageInfo> batch, CancellationToken ct)
     {
         var queries = batch.Select(p =>
         {
-            var query = new Dictionary<string, object>();
             var pkg = new Dictionary<string, string> { ["name"] = p.Name };
-
             if (!string.IsNullOrEmpty(p.Ecosystem))
                 pkg["ecosystem"] = p.Ecosystem;
 
-            query["package"] = pkg;
-            query["version"] = p.Version;
-            return query;
+            return new Dictionary<string, object>
+            {
+                ["package"] = pkg,
+                ["version"] = p.Version
+            };
         }).ToList();
-
-        var requestBody = new { queries };
 
         try
         {
-            using var response = await httpClient.PostAsJsonAsync(OsvBatchUrl, requestBody, ct);
+            using var response = await httpClient.PostAsJsonAsync(OsvBatchUrl, new { queries }, ct);
             response.EnsureSuccessStatusCode();
-            var responseJson = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
-            return ParseBatchResponse(batch, responseJson);
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+            return ExtractVulnIds(batch, json);
         }
         catch (Exception) when (!ct.IsCancellationRequested)
         {
-            // Return empty results for failed requests rather than crashing
-            return batch.Select(p => new VulnerabilityResult(p.Name, p.Version, [])).ToList();
+            return batch.Select(p => (p, new List<string>())).ToList();
         }
     }
 
-    private static List<VulnerabilityResult> ParseBatchResponse(
+    private static List<(PackageInfo Package, List<string> VulnIds)> ExtractVulnIds(
         List<PackageInfo> batch, JsonElement responseJson)
     {
-        var results = new List<VulnerabilityResult>();
+        var results = new List<(PackageInfo, List<string>)>();
 
         if (!responseJson.TryGetProperty("results", out var resultsArray) ||
             resultsArray.ValueKind != JsonValueKind.Array)
         {
-            return batch.Select(p => new VulnerabilityResult(p.Name, p.Version, [])).ToList();
+            return batch.Select(p => (p, new List<string>())).ToList();
         }
 
         var index = 0;
@@ -84,29 +119,72 @@ public class VulnerabilityService(HttpClient httpClient)
         {
             if (index >= batch.Count) break;
 
-            var pkg = batch[index];
-            var vulns = new List<VulnerabilityEntry>();
-
+            var ids = new List<string>();
             if (result.TryGetProperty("vulns", out var vulnsArray) &&
                 vulnsArray.ValueKind == JsonValueKind.Array)
             {
                 foreach (var vuln in vulnsArray.EnumerateArray())
                 {
-                    vulns.Add(ParseVulnerability(vuln));
+                    if (vuln.TryGetProperty("id", out var idEl) && idEl.GetString() is string id)
+                        ids.Add(id);
                 }
             }
 
-            results.Add(new VulnerabilityResult(pkg.Name, pkg.Version, vulns));
+            results.Add((batch[index], ids));
             index++;
         }
 
-        // If response had fewer results than batch, fill remaining with empty
         for (; index < batch.Count; index++)
-        {
-            results.Add(new VulnerabilityResult(batch[index].Name, batch[index].Version, []));
-        }
+            results.Add((batch[index], []));
 
         return results;
+    }
+
+    private async Task<Dictionary<string, VulnerabilityEntry>> FetchVulnDetailsAsync(
+        List<string> vulnIds, Action<int, int>? onProgress, CancellationToken ct)
+    {
+        var details = new Dictionary<string, VulnerabilityEntry>();
+        if (vulnIds.Count == 0) return details;
+
+        onProgress?.Invoke(0, vulnIds.Count);
+
+        var semaphore = new SemaphoreSlim(MaxConcurrentDetailFetches);
+        var done = 0;
+
+        var tasks = vulnIds.Select(async id =>
+        {
+            await semaphore.WaitAsync(ct);
+            try
+            {
+                ct.ThrowIfCancellationRequested();
+                var entry = await FetchVulnDetailAsync(id, ct);
+                lock (details) details[id] = entry;
+            }
+            finally
+            {
+                semaphore.Release();
+                onProgress?.Invoke(Interlocked.Increment(ref done), vulnIds.Count);
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        return details;
+    }
+
+    private async Task<VulnerabilityEntry> FetchVulnDetailAsync(string id, CancellationToken ct)
+    {
+        try
+        {
+            using var response = await httpClient.GetAsync(
+                $"{OsvVulnDetailUrl}{Uri.EscapeDataString(id)}", ct);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+            return ParseVulnerability(json);
+        }
+        catch (Exception) when (!ct.IsCancellationRequested)
+        {
+            return new VulnerabilityEntry(id, null, null, null, null);
+        }
     }
 
     internal static VulnerabilityEntry ParseVulnerability(JsonElement vuln)
@@ -117,7 +195,31 @@ public class VulnerabilityService(HttpClient httpClient)
         string? severity = null;
         double? cvssScore = null;
 
-        // Try severity from database_specific or severity array
+        // Try database_specific first — most reliable across GHSA, NVD, PyPA, Go, npm
+        if (vuln.TryGetProperty("database_specific", out var dbSpecific))
+        {
+            if (dbSpecific.TryGetProperty("severity", out var dbSev))
+                severity = NormalizeSeverity(dbSev.GetString());
+
+            // Some sources (GHSA) embed numeric score under database_specific.cvss.score
+            if (dbSpecific.TryGetProperty("cvss", out var cvssObj) &&
+                cvssObj.TryGetProperty("score", out var cvssScoreEl) &&
+                cvssScoreEl.ValueKind == JsonValueKind.Number)
+            {
+                cvssScore = cvssScoreEl.GetDouble();
+                severity ??= CvssToSeverity(cvssScore.Value);
+            }
+        }
+
+        // Try ecosystem_specific.severity (used by PyPA, Go, etc.)
+        if (severity == null &&
+            vuln.TryGetProperty("ecosystem_specific", out var ecoSpecific) &&
+            ecoSpecific.TryGetProperty("severity", out var ecoSev))
+        {
+            severity = NormalizeSeverity(ecoSev.GetString());
+        }
+
+        // Try severity array — score field may be a plain numeric string like "7.5"
         if (vuln.TryGetProperty("severity", out var sevArray) &&
             sevArray.ValueKind == JsonValueKind.Array)
         {
@@ -129,32 +231,16 @@ public class VulnerabilityService(HttpClient httpClient)
                     var scoreStr = scoreEl.GetString();
                     if (scoreStr != null && TryExtractCvssScore(scoreStr, out var score))
                     {
-                        cvssScore = score;
-                        severity = CvssToSeverity(score);
+                        cvssScore ??= score;
+                        severity ??= CvssToSeverity(score);
                     }
                 }
 
+                // Prefer CVSS_V3 entry and stop after processing it
                 if (sev.TryGetProperty("type", out var typeEl) &&
-                    typeEl.GetString() == "CVSS_V3" &&
-                    sev.TryGetProperty("score", out var cvss3Score))
-                {
-                    var cvss3Str = cvss3Score.GetString();
-                    if (cvss3Str != null && TryExtractCvssScore(cvss3Str, out var score3))
-                    {
-                        cvssScore = score3;
-                        severity = CvssToSeverity(score3);
-                        break; // Prefer CVSS v3
-                    }
-                }
+                    typeEl.GetString() == "CVSS_V3")
+                    break;
             }
-        }
-
-        // Try database_specific severity as fallback
-        if (severity == null &&
-            vuln.TryGetProperty("database_specific", out var dbSpecific) &&
-            dbSpecific.TryGetProperty("severity", out var dbSev))
-        {
-            severity = dbSev.GetString()?.ToUpperInvariant();
         }
 
         // Extract fixed version from affected ranges
@@ -191,11 +277,16 @@ public class VulnerabilityService(HttpClient httpClient)
         return new VulnerabilityEntry(id, summary, severity, cvssScore, fixedVersion);
     }
 
+    private static string? NormalizeSeverity(string? raw) => raw?.ToUpperInvariant() switch
+    {
+        "MODERATE" => "MEDIUM",  // GitHub Advisory Database uses MODERATE
+        null => null,
+        var s => s
+    };
+
     private static bool TryExtractCvssScore(string cvssVector, out double score)
     {
         score = 0;
-        // CVSS vector format: "CVSS:3.1/AV:N/AC:L/..." — score is sometimes appended
-        // or the score field is just a numeric string like "7.5"
         if (double.TryParse(cvssVector, System.Globalization.CultureInfo.InvariantCulture, out score))
             return true;
 

--- a/tests/SBOMViewer.Blazor.Tests/Services/ChatStateTests.cs
+++ b/tests/SBOMViewer.Blazor.Tests/Services/ChatStateTests.cs
@@ -48,6 +48,7 @@ public class ChatStateTests
         state.ScanProgress = 5;
         state.ScanTotal = 10;
         state.ScanError = "error";
+        state.ScanWarnings.Add("some warning");
 
         state.ClearVulnerabilities();
 
@@ -56,6 +57,7 @@ public class ChatStateTests
         state.ScanProgress.Should().Be(0);
         state.ScanTotal.Should().Be(0);
         state.ScanError.Should().BeNull();
+        state.ScanWarnings.Should().BeEmpty();
     }
 
     [Fact]
@@ -67,6 +69,7 @@ public class ChatStateTests
         state.IsChatPanelOpen = true;
         state.VulnResults = [new VulnerabilityResult("pkg", "1.0", [])];
         state.IsScanning = true;
+        state.ScanWarnings.Add("some warning");
 
         state.Clear();
 
@@ -75,6 +78,7 @@ public class ChatStateTests
         state.IsChatPanelOpen.Should().BeFalse();
         state.VulnResults.Should().BeNull();
         state.IsScanning.Should().BeFalse();
+        state.ScanWarnings.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/SBOMViewer.Blazor.Tests/Services/VulnerabilityServiceTests.cs
+++ b/tests/SBOMViewer.Blazor.Tests/Services/VulnerabilityServiceTests.cs
@@ -115,59 +115,95 @@ public class VulnerabilityServiceTests
         AssertSeverity("0.0", "NONE");
     }
 
+    [Fact]
+    public void ParseVulnerability_ModerateNormalizedToMedium()
+    {
+        // GitHub Advisory Database uses "MODERATE" instead of "MEDIUM"
+        var json = JsonDocument.Parse("""
+            {
+                "id": "GHSA-xxxx-0001",
+                "database_specific": { "severity": "MODERATE" }
+            }
+            """).RootElement;
+
+        var result = VulnerabilityService.ParseVulnerability(json);
+
+        result.Severity.Should().Be("MEDIUM");
+    }
+
+    [Fact]
+    public void ParseVulnerability_DatabaseSpecificTakesPrecedenceOverSeverityArray()
+    {
+        // database_specific.severity should win over a computed CVSS score
+        var json = JsonDocument.Parse("""
+            {
+                "id": "GHSA-xxxx-0002",
+                "severity": [{ "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }],
+                "database_specific": { "severity": "CRITICAL" }
+            }
+            """).RootElement;
+
+        var result = VulnerabilityService.ParseVulnerability(json);
+
+        result.Severity.Should().Be("CRITICAL");
+    }
+
+    [Fact]
+    public void ParseVulnerability_EcosystemSpecificSeverity()
+    {
+        // PyPA, Go, and others use ecosystem_specific.severity
+        var json = JsonDocument.Parse("""
+            {
+                "id": "PYSEC-2024-001",
+                "ecosystem_specific": { "severity": "HIGH" }
+            }
+            """).RootElement;
+
+        var result = VulnerabilityService.ParseVulnerability(json);
+
+        result.Severity.Should().Be("HIGH");
+    }
+
     // ─── ScanAsync ──────────────────────────────────────────
 
     [Fact]
     public async Task ScanAsync_SinglePackage_ReturnsResults()
     {
-        var responseJson = """
-            {
-                "results": [
-                    {
-                        "vulns": [
-                            {
-                                "id": "CVE-2024-1234",
-                                "summary": "Test vuln",
-                                "database_specific": { "severity": "HIGH" }
-                            }
-                        ]
-                    }
-                ]
-            }
-            """;
+        // Batch returns one vuln ID; detail fetch returns full record
+        var handler = new RouteAwareMockHandler(request =>
+        {
+            if (request.RequestUri!.PathAndQuery.Contains("querybatch"))
+                return OkJson("""{ "results": [{ "vulns": [{ "id": "CVE-2024-1234" }] }] }""");
 
-        var handler = new MockHttpHandler(responseJson);
+            if (request.RequestUri.PathAndQuery.Contains("CVE-2024-1234"))
+                return OkJson("""{ "id": "CVE-2024-1234", "summary": "Test vuln", "database_specific": { "severity": "HIGH" } }""");
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
         var service = new VulnerabilityService(client);
 
-        var packages = new List<PackageInfo>
-        {
-            new("lodash", "4.17.20", "npm", "pkg:npm/lodash@4.17.20")
-        };
-
-        var results = await service.ScanAsync(packages);
+        var results = await service.ScanAsync(
+            [new("lodash", "4.17.20", "npm", "pkg:npm/lodash@4.17.20")]);
 
         results.Should().HaveCount(1);
         results[0].PackageName.Should().Be("lodash");
         results[0].Vulnerabilities.Should().HaveCount(1);
         results[0].Vulnerabilities[0].Id.Should().Be("CVE-2024-1234");
+        results[0].Vulnerabilities[0].Severity.Should().Be("HIGH");
     }
 
     [Fact]
     public async Task ScanAsync_NoVulnerabilities_ReturnsEmptyList()
     {
-        var responseJson = """{ "results": [{ "vulns": [] }] }""";
+        var handler = new RouteAwareMockHandler(_ =>
+            OkJson("""{ "results": [{ "vulns": [] }] }"""));
 
-        var handler = new MockHttpHandler(responseJson);
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
         var service = new VulnerabilityService(client);
 
-        var packages = new List<PackageInfo>
-        {
-            new("safe-package", "1.0.0", "npm", null)
-        };
-
-        var results = await service.ScanAsync(packages);
+        var results = await service.ScanAsync([new("safe-package", "1.0.0", "npm", null)]);
 
         results.Should().HaveCount(1);
         results[0].Vulnerabilities.Should().BeEmpty();
@@ -176,16 +212,13 @@ public class VulnerabilityServiceTests
     [Fact]
     public async Task ScanAsync_HttpError_ReturnsEmptyVulns()
     {
-        var handler = new MockHttpHandler(statusCode: HttpStatusCode.InternalServerError);
+        var handler = new RouteAwareMockHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
         var service = new VulnerabilityService(client);
 
-        var packages = new List<PackageInfo>
-        {
-            new("pkg", "1.0.0", "npm", null)
-        };
-
-        var results = await service.ScanAsync(packages);
+        var results = await service.ScanAsync([new("pkg", "1.0.0", "npm", null)]);
 
         results.Should().HaveCount(1);
         results[0].Vulnerabilities.Should().BeEmpty();
@@ -194,27 +227,30 @@ public class VulnerabilityServiceTests
     [Fact]
     public async Task ScanAsync_ProgressCallback_Invoked()
     {
-        var responseJson = """{ "results": [{}] }""";
-        var handler = new MockHttpHandler(responseJson);
+        var handler = new RouteAwareMockHandler(request =>
+        {
+            if (request.RequestUri!.PathAndQuery.Contains("querybatch"))
+                return OkJson("""{ "results": [{ "vulns": [{ "id": "CVE-2024-0001" }] }] }""");
+
+            return OkJson("""{ "id": "CVE-2024-0001", "database_specific": { "severity": "LOW" } }""");
+        });
+
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
         var service = new VulnerabilityService(client);
 
-        var packages = new List<PackageInfo>
-        {
-            new("pkg", "1.0.0", "npm", null)
-        };
-
         var progressCalls = new List<(int done, int total)>();
-        await service.ScanAsync(packages, (done, total) => progressCalls.Add((done, total)));
+        await service.ScanAsync(
+            [new("pkg", "1.0.0", "npm", null)],
+            (done, total) => progressCalls.Add((done, total)));
 
-        progressCalls.Should().ContainSingle()
-            .Which.Should().Be((1, 1));
+        progressCalls.Should().Contain((0, 1)); // phase 2 start
+        progressCalls.Should().Contain((1, 1)); // phase 2 done
     }
 
     [Fact]
     public async Task ScanAsync_EmptyPackageList_ReturnsEmpty()
     {
-        var handler = new MockHttpHandler("{}");
+        var handler = new RouteAwareMockHandler(_ => OkJson("{}"));
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
         var service = new VulnerabilityService(client);
 
@@ -226,45 +262,123 @@ public class VulnerabilityServiceTests
     [Fact]
     public async Task ScanAsync_MalformedResponse_ReturnsEmptyVulns()
     {
-        var handler = new MockHttpHandler("""{ "unexpected": "format" }""");
+        var handler = new RouteAwareMockHandler(_ =>
+            OkJson("""{ "unexpected": "format" }"""));
+
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
         var service = new VulnerabilityService(client);
 
-        var packages = new List<PackageInfo>
-        {
-            new("pkg", "1.0.0", "npm", null)
-        };
-
-        var results = await service.ScanAsync(packages);
+        var results = await service.ScanAsync([new("pkg", "1.0.0", "npm", null)]);
 
         results.Should().HaveCount(1);
         results[0].Vulnerabilities.Should().BeEmpty();
     }
 
-    // ─── Mock HTTP Handler ──────────────────────────────────
-
-    private class MockHttpHandler : HttpMessageHandler
+    [Fact]
+    public async Task ScanAsync_SameVulnAcrossMultiplePackages_FetchedOnce()
     {
-        private readonly string? _responseBody;
-        private readonly HttpStatusCode _statusCode;
-        public int RequestCount { get; private set; }
-
-        public MockHttpHandler(string? responseBody = null, HttpStatusCode statusCode = HttpStatusCode.OK)
+        var detailRequestCount = 0;
+        var handler = new RouteAwareMockHandler(request =>
         {
-            _responseBody = responseBody;
-            _statusCode = statusCode;
-        }
+            if (request.RequestUri!.PathAndQuery.Contains("querybatch"))
+                return OkJson("""
+                    {
+                        "results": [
+                            { "vulns": [{ "id": "CVE-2024-SHARED" }] },
+                            { "vulns": [{ "id": "CVE-2024-SHARED" }] }
+                        ]
+                    }
+                    """);
 
+            detailRequestCount++;
+            return OkJson("""{ "id": "CVE-2024-SHARED", "database_specific": { "severity": "HIGH" } }""");
+        });
+
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
+        var service = new VulnerabilityService(client);
+
+        var results = await service.ScanAsync([
+            new("pkg-a", "1.0.0", "npm", null),
+            new("pkg-b", "2.0.0", "npm", null)
+        ]);
+
+        detailRequestCount.Should().Be(1);
+        results.Should().HaveCount(2);
+        results[0].Vulnerabilities[0].Severity.Should().Be("HIGH");
+        results[1].Vulnerabilities[0].Severity.Should().Be("HIGH");
+    }
+
+    [Fact]
+    public async Task ScanAsync_ExceedsPackageCap_TruncatesAndWarns()
+    {
+        var handler = new RouteAwareMockHandler(request =>
+        {
+            if (request.RequestUri!.PathAndQuery.Contains("querybatch"))
+                return OkJson("""{ "results": [] }""");
+            return OkJson("{}");
+        });
+
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
+        var service = new VulnerabilityService(client);
+
+        var packages = Enumerable.Range(1, VulnerabilityService.MaxPackagesToScan + 50)
+            .Select(i => new PackageInfo($"pkg-{i}", "1.0.0", "npm", null))
+            .ToList();
+
+        var warnings = new List<string>();
+        var results = await service.ScanAsync(packages, onWarning: w => warnings.Add(w));
+
+        // Results are capped — excess packages are not returned
+        results.Should().HaveCount(VulnerabilityService.MaxPackagesToScan);
+        warnings.Should().ContainSingle()
+            .Which.Should().Contain(VulnerabilityService.MaxPackagesToScan.ToString());
+    }
+
+    [Fact]
+    public async Task ScanAsync_ExceedsVulnDetailCap_TruncatesAndWarns()
+    {
+        var detailsFetched = 0;
+        var handler = new RouteAwareMockHandler(request =>
+        {
+            if (request.RequestUri!.PathAndQuery.Contains("querybatch"))
+            {
+                // Return MaxVulnDetailFetches + 50 unique vuln IDs for a single package
+                var ids = Enumerable.Range(1, VulnerabilityService.MaxVulnDetailFetches + 50)
+                    .Select(i => $$"""{ "id": "CVE-2024-{{i:D4}}" }""");
+                return OkJson($$"""{ "results": [{ "vulns": [{{string.Join(",", ids)}}] }] }""");
+            }
+
+            // Individual detail fetch
+            detailsFetched++;
+            return OkJson("""{ "id": "CVE", "database_specific": { "severity": "HIGH" } }""");
+        });
+
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.osv.dev") };
+        var service = new VulnerabilityService(client);
+
+        var warnings = new List<string>();
+        await service.ScanAsync(
+            [new("pkg", "1.0.0", "npm", null)],
+            onWarning: w => warnings.Add(w));
+
+        detailsFetched.Should().Be(VulnerabilityService.MaxVulnDetailFetches);
+        warnings.Should().ContainSingle()
+            .Which.Should().Contain(VulnerabilityService.MaxVulnDetailFetches.ToString());
+    }
+
+    // ─── Helpers ────────────────────────────────────────────
+
+    private static HttpResponseMessage OkJson(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private class RouteAwareMockHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        : HttpMessageHandler
+    {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            RequestCount++;
-
-            var response = new HttpResponseMessage(_statusCode);
-            if (_responseBody != null)
-                response.Content = new StringContent(_responseBody, Encoding.UTF8, "application/json");
-
-            return Task.FromResult(response);
-        }
+            => Task.FromResult(handler(request));
     }
 }


### PR DESCRIPTION
### What changed
- `VulnerabilityService`: upgraded from single-phase batch query to two-phase scan — Phase 1 collects vuln IDs via `querybatch`, Phase 2 fetches full details per unique ID (`GET /v1/vulns/{id}`) with up to 5 concurrent requests
- Hard caps added: max 500 packages scanned, max 200 unique vuln detail fetches per scan; exceeding either fires a warning
- `ChatState`: added `ScanWarnings` list to accumulate non-fatal cap/truncation notices
- `DynamicSbomViewer`: warning banners for cap exceeded, progress overlay now tracks detail fetch phase
- `VulnerabilitySummary`: per-package severity badge breakdown (replaces single combined badge)
- `VulnerabilityBadge`: MEDIUM badge now uses dark text (`#1a1a1a`) on amber for legibility
- `CLAUDE.md`: updated to document two-phase scan architecture

### Why
The original single-phase batch query only returned vuln IDs — severity, CVSS scores, summaries, and fix versions were incomplete or missing. The detail fetch phase provides complete data. Hard caps prevent runaway API usage on large SBOMs.

### How to test
1. Upload a CycloneDX or SPDX SBOM with known vulnerable packages
2. Click "Scan for Vulnerabilities"
3. Verify progress overlay shows both batch and detail fetch phases
4. Verify `VulnerabilitySummary` shows per-severity badge breakdown per package
5. Upload an SBOM with >500 packages — verify warning banner appears
6. Run unit tests: `dotnet test tests/SBOMViewer.Blazor.Tests`

### Screenshots
_(UI changes present — please capture vulnerability scan progress overlay and per-package severity badges)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)