### PR TITLE
feat(compliance): add license risk classification and printable repor…

### DIFF
--- a/docs/license-compliance-and-report-export/license-compliance-plan.md
+++ b/docs/license-compliance-and-report-export/license-compliance-plan.md
@@ -1,0 +1,119 @@
+# Plan: License Compliance Report — SBOMViewer
+
+## Context
+
+SBOMViewer gets ~10 visits/day and is a 100% client-side static app (no backend, no accounts). To grow organic traffic and make the product more credible for enterprise/compliance use, this plan adds license-risk classification: instead of just listing the raw license string per component, components are bucketed into permissive / weak-copyleft / strong-copyleft / unknown so risky or unclear licenses are surfaced automatically. This is the single most-searched-for SBOM use case after vulnerability scanning, and the raw license data is already half-extracted.
+
+Stays fully client-side — no new backend, no new npm/CDN dependencies, no accounts.
+
+**Release:** `license-compliance-report` (Phase 1)
+**Companion plan:** [report-export-plan.md](./report-export-plan.md) (Phase 2 — printable report, depends on this phase's risk-bucket data)
+
+Existing groundwork found in `src/SBOMViewer.Blazor/Components/DynamicSbomViewer.razor`:
+- `ComponentRow` record (line 156) and `ExtractComponentRows()` (line 236) already extract `License` per component (CycloneDX `licenses[].license.id`/`expression`, SPDX `licenseConcluded`). It's missing the CycloneDX `license.name` fallback (e.g. "PostgreSQL License" sample currently falls through as license.id-only — needs a name fallback too).
+- `_licenseDist` (line 135/191-197) already builds a top-5 license histogram shown in the Overview tab's "License Distribution" widget — this is reused, not replaced.
+- Sidebar tab pattern (lines 26-90) — `_activeTab`, `SetTab()`, `sidebar-item` buttons with icon/label/count badge — new "Compliance" tab follows this exact pattern.
+- Stat-card / sev-bar CSS classes already in `wwwroot/css/app.css` are reused for the new tab's summary cards.
+
+---
+
+## File Structure
+
+```
+src/SBOMViewer.Blazor/
+├── Models/
+│   └── LicenseRisk.cs                  # Enum: Permissive, WeakCopyleft, StrongCopyleft, Proprietary, Unknown
+├── Services/
+│   └── LicenseClassifier.cs            # Static SPDX-id -> LicenseRisk classifier
+└── Components/
+    └── DynamicSbomViewer.razor         # New "Compliance" tab (modified)
+
+tests/SBOMViewer.Blazor.Tests/
+└── Services/
+    └── LicenseClassifierTests.cs       # Table-driven classification tests
+```
+
+---
+
+## Phase 1: License Compliance Classification
+
+### 1.1 New Model
+
+**`Models/LicenseRisk.cs`**
+```csharp
+public enum LicenseRisk { Permissive, WeakCopyleft, StrongCopyleft, Proprietary, Unknown }
+```
+
+### 1.2 LicenseClassifier Service (`Services/LicenseClassifier.cs`)
+
+Static class, `Classify(string? license) -> LicenseRisk`. Curated lookup table (~50-60 common SPDX identifiers covering licenses likely to appear in real-world .NET/npm/PyPI SBOMs):
+
+- **Permissive**: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense, PostgreSQL, Python-2.0, Zlib
+- **Weak-copyleft**: LGPL-2.1, LGPL-3.0, MPL-2.0, EPL-1.0, EPL-2.0, CDDL-1.0/1.1
+- **Strong-copyleft**: GPL-2.0, GPL-3.0, AGPL-3.0, SSPL-1.0
+- **Unknown**: anything unmatched — custom license name, `NOASSERTION`, empty, or unrecognized SPDX id
+
+Match case-insensitively; strip common suffixes (`-only`, `-or-later`, trailing `+`) before lookup.
+
+### 1.3 Unit Tests
+
+**`tests/SBOMViewer.Blazor.Tests/Services/LicenseClassifierTests.cs`** — table-driven tests covering each bucket, case-insensitivity, and unknown/empty fallback.
+
+### 1.4 Modify `DynamicSbomViewer.razor`
+
+- Extend `ComponentRow` with `LicenseRisk Risk`.
+- In `ExtractComponentRows()`: add `license.name` fallback for CycloneDX (when `license.id` is absent), call `LicenseClassifier.Classify(license)` when building each row.
+- In `BuildDerivedData()`: compute risk-bucket counts (`_permissiveCount`, `_weakCopyleftCount`, `_strongCopyleftCount`, `_unknownLicenseCount`) alongside the existing `_licenseDist`.
+- Add new sidebar tab `"compliance"` (between "Vulnerabilities" and dynamic sections), with a badge showing strong-copyleft + unknown count in a warning color when > 0 (mirrors the vuln count badge pattern at lines 49-52).
+- New `RenderComplianceTab()` method (mirrors `RenderComponentsTab()` pattern):
+  - 4 stat-cards (Permissive / Weak Copyleft / Strong Copyleft / Unknown) reusing `.stat-card` styling.
+  - A flagged list: all components with `Risk` in `{StrongCopyleft, Unknown}`, sortable/searchable like the Components tab (new `_complianceSearch` / `_complianceRiskFilter` local state, same pattern as `_compSearch`).
+  - Each row shows component name, version, raw license string, and a colored risk badge (new `.license-risk-badge` CSS classes: `.risk-strong` red, `.risk-weak` amber, `.risk-unknown` gray, `.risk-permissive` green — same visual language as `.sev-badge`).
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Curated SPDX lookup table (not full SPDX license list) | Covers the licenses that actually appear in .NET/npm/PyPI SBOMs; full list (~600 entries) is unnecessary bundle weight for marginal coverage gain |
+| Unknown bucket as default fallback | Custom/non-SPDX license strings should be flagged for manual review, not silently miscategorized |
+| New tab follows existing sidebar/stat-card pattern | Visual consistency with Overview/Components/Vulnerabilities tabs already in `DynamicSbomViewer.razor` |
+
+---
+
+## Verification
+
+1. `dotnet build SBOMViewer.slnx` — compiles with no errors.
+2. `dotnet test --filter "FullyQualifiedName~LicenseClassifier"` — new classifier tests pass.
+3. `dotnet test` — full suite still passes (existing `SchemaServiceTests`, `PackageExtractorTests`, etc. unaffected since changes are additive).
+4. Manual run (`dotnet run --project src/SBOMViewer.Blazor`):
+   - Upload `samples/cyclonedx-1.7-full.json` and `samples/spdx-2.2-full.json` — verify the new "Compliance" tab shows correct risk-bucket counts and flags any GPL/AGPL/unknown-licensed components.
+5. Re-check the CycloneDX `license.name` fallback against a sample component that only has `license.name` (e.g. "PostgreSQL License" in the existing sample) to confirm it no longer shows as blank/Unknown incorrectly.
+
+---
+
+## Execution Plan (Step-by-Step)
+
+### Step 1: License Risk Model & Classifier
+- [ ] Create `src/SBOMViewer.Blazor/Models/LicenseRisk.cs`
+- [ ] Create `src/SBOMViewer.Blazor/Services/LicenseClassifier.cs` with curated lookup table
+- [ ] Create `tests/SBOMViewer.Blazor.Tests/Services/LicenseClassifierTests.cs`
+- [ ] `dotnet test --filter "FullyQualifiedName~LicenseClassifier"`
+
+### Step 2: Wire Classification into Component Extraction
+- [ ] Extend `ComponentRow` with `LicenseRisk Risk` in `DynamicSbomViewer.razor`
+- [ ] Add CycloneDX `license.name` fallback in `ExtractComponentRows()`
+- [ ] Call `LicenseClassifier.Classify()` per row
+- [ ] Compute risk-bucket counts in `BuildDerivedData()`
+
+### Step 3: Compliance Tab UI
+- [ ] Add `"compliance"` sidebar tab with warning badge
+- [ ] Implement `RenderComplianceTab()` — stat-cards + flagged/searchable list
+- [ ] Add `.license-risk-badge` CSS variants to `app.css`
+- [ ] `dotnet build` + manual test with sample SBOMs
+
+### Step 4: Testing & Polish
+- [ ] Run all unit tests: `dotnet test`
+- [ ] Manual end-to-end test with `samples/cyclonedx-1.7-full.json` and `samples/spdx-2.2-full.json`
+- [ ] Verify CycloneDX `license.name` fallback fix doesn't regress existing license.id-based rows

--- a/docs/license-compliance-and-report-export/report-export-plan.md
+++ b/docs/license-compliance-and-report-export/report-export-plan.md
@@ -1,0 +1,91 @@
+# Plan: Printable Report Export — SBOMViewer
+
+## Context
+
+SBOMViewer gets ~10 visits/day and is a 100% client-side static app (no backend, no accounts). This plan adds a "Export Report" feature: a clean, printable report combining SBOM summary, vulnerability findings, and license compliance results, exported via the browser's native print dialog (save-as-PDF). This turns the tool into something usable as an actual audit deliverable — the kind of feature that justifies a paid/pro tier later — while staying fully client-side (no new backend, no new npm/CDN dependencies, no accounts).
+
+**Release:** `license-compliance-report` (Phase 2)
+**Depends on:** [license-compliance-plan.md](./license-compliance-plan.md) (Phase 1 — provides the license risk-bucket data and `LicenseRisk` classification used in the report)
+
+Existing groundwork found in `src/SBOMViewer.Blazor/`:
+- `Components/DynamicSbomViewer.razor` already computes everything the report needs: `_componentRows`, `ChatState.VulnResults`, `_generatedDate`, plus the new license risk-bucket counts from Phase 1.
+- JS interop pattern: flat `window.sbomXxx` functions in `wwwroot/index.html` (e.g. `sbomDownloadFile`, lines 110-118), called via `JS.InvokeVoidAsync(...)`. A new `sbomPrintReport` function follows this exact pattern.
+- No `@media print` rules exist yet in `wwwroot/css/app.css` (488 lines, checked).
+
+---
+
+## File Structure
+
+```
+src/SBOMViewer.Blazor/
+├── Components/
+│   └── DynamicSbomViewer.razor         # New print-report block + Export button (modified)
+└── wwwroot/
+    ├── index.html                      # New window.sbomPrintReport function (modified)
+    └── css/app.css                     # New @media print rules (modified)
+```
+
+---
+
+## Phase 2: Printable Report Export
+
+### Approach
+
+Use the browser's native print-to-PDF (no jsPDF/html2canvas) — zero bundle size cost, works offline, matches the "stay client-side only" constraint. Tradeoff: less pixel-perfect than a JS PDF library, acceptable for a v1 audit-style report.
+
+### 2.1 Modify `DynamicSbomViewer.razor`
+
+- Add an "Export Report" button near the SBOM meta widget (sidebar, line ~76-89) — calls `JS.InvokeVoidAsync("sbomPrintReport")`.
+- Add a hidden-by-default `<div class="print-report">` block (rendered always, visibility controlled purely by CSS so print captures full data regardless of active tab) containing:
+  - Header: filename, format/spec version, generated date, scan date (reuse existing fields: `FileName`, `SbomState.DetectedFormat`, `_generatedDate`)
+  - Summary stats (component count, total vulns by severity, license risk bucket counts)
+  - Full vulnerability list (package, CVE id, severity, CVSS, fixed version) — reuse data already in `ChatState.VulnResults`, no new extraction needed
+  - Full license compliance list — components flagged `StrongCopyleft`/`Unknown` (from Phase 1), plus the full `_licenseDist` table
+- This block reuses already-computed fields (`_componentRows`, `ChatState.VulnResults`, risk-bucket counts) — no duplicate data fetching.
+
+### 2.2 Modify `wwwroot/index.html`
+
+Add next to `sbomDownloadFile` (line ~118), following the same flat-function convention:
+```js
+window.sbomPrintReport = function () { window.print(); };
+```
+
+### 2.3 Modify `wwwroot/css/app.css`
+
+- Add `.print-report { display: none; }` for screen.
+- Add `@media print { .dashboard .sidebar, .stat-card button, .btn-ghost, .btn-primary { display: none; } .print-report { display: block; } ... }` — hide the live dashboard chrome, show only the print-report block, add `page-break-inside: avoid` on report sections and basic black-on-white report typography.
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Browser print-to-PDF (not jsPDF/html2canvas) | Zero added bundle size, no new dependency, works fully offline — matches client-side-only constraint |
+| Print-report block always rendered, CSS-gated | Print should capture the full report regardless of which tab is currently active on screen |
+
+---
+
+## Verification
+
+1. `dotnet build SBOMViewer.slnx` — compiles with no errors.
+2. Manual run (`dotnet run --project src/SBOMViewer.Blazor`):
+   - Upload `samples/cyclonedx-1.7-full.json` or `samples/spdx-2.2-full.json`, run a vulnerability scan, then go to the Compliance tab (from Phase 1).
+   - Click "Export Report" — verify the browser print dialog opens showing a clean report (no sidebar/buttons), save as PDF, confirm vulnerability and license sections render correctly with page breaks.
+3. Test in both Chrome and Edge print preview to confirm consistent layout.
+
+---
+
+## Execution Plan (Step-by-Step)
+
+### Step 1: Print Report Block
+- [ ] Add `<div class="print-report">` block to `DynamicSbomViewer.razor` with header, summary, vuln list, license list
+- [ ] Add "Export Report" button wired to `sbomPrintReport` JS interop
+- [ ] Add `window.sbomPrintReport` to `index.html`
+
+### Step 2: Print Styles
+- [ ] Add `@media print` rules to `app.css` (hide chrome, show report, page breaks)
+- [ ] Manual test: print preview / save-as-PDF in Chrome and Edge
+
+### Step 3: Testing & Polish
+- [ ] `dotnet build` + full manual end-to-end test with sample SBOMs (scan + export)

--- a/src/SBOMViewer.Blazor/Components/DynamicSbomViewer.razor
+++ b/src/SBOMViewer.Blazor/Components/DynamicSbomViewer.razor
@@ -5,6 +5,7 @@
 @inject ChatState ChatState
 @inject VulnerabilityService VulnService
 @inject SbomState SbomState
+@inject IJSRuntime JS
 
 @* ── Scan overlay ── *@
 @if (ChatState.IsScanning)
@@ -52,6 +53,19 @@
                 }
             </button>
 
+            @if (_componentCount > 0)
+            {
+                <button class="sidebar-item @(_activeTab == "compliance" ? "active" : "")"
+                        @onclick='() => SetTab("compliance")'>
+                    <span class="si-icon">⚖</span>
+                    <span class="si-label">Compliance</span>
+                    @if (_strongCopyleftCount + _unknownLicenseCount > 0)
+                    {
+                        <span class="si-count" style="color:var(--med); background:oklch(78% 0.18 80 / 0.12);">@(_strongCopyleftCount + _unknownLicenseCount)</span>
+                    }
+                </button>
+            }
+
             @if (_dynamicSections.Count > 0)
             {
                 <div class="sidebar-section" style="margin-top:8px;">Sections</div>
@@ -87,6 +101,10 @@
                 }
                 <div class="sbom-meta-row"><span>Components</span><span>@_componentCount</span></div>
             </div>
+
+            <button class="btn-ghost" style="margin:10px 12px 0; width:calc(100% - 24px);" @onclick="ExportReport">
+                ⤓ Export Report
+            </button>
         </div>
 
         @* ── Main area ── *@
@@ -103,6 +121,10 @@
             {
                 @RenderVulnsTab()
             }
+            else if (_activeTab == "compliance")
+            {
+                @RenderComplianceTab()
+            }
             else if (_dynamicSections.TryGetValue(_activeTab, out var dynSec))
             {
                 <div class="tab-bar">
@@ -116,6 +138,115 @@
                 </div>
             }
         </div>
+    </div>
+
+    @* ── Printable report (screen-hidden, shown only via @media print) ── *@
+    <div class="print-report">
+        <h1>SBOM Compliance Report</h1>
+        <div class="print-meta">
+            <div><strong>File:</strong> @FileName</div>
+            @if (SbomState.DetectedFormat is not null)
+            {
+                <div><strong>Format:</strong> @GetFormatName(SbomState.DetectedFormat.Value) @GetFormatVersion(SbomState.DetectedFormat.Value)</div>
+            }
+            @if (_generatedDate is not null)
+            {
+                <div><strong>SBOM generated:</strong> @_generatedDate</div>
+            }
+            <div><strong>Report exported:</strong> @DateTime.Now.ToString("yyyy-MM-dd HH:mm")</div>
+            <div><strong>Total components:</strong> @_componentCount</div>
+        </div>
+
+        <h2>Vulnerability Summary</h2>
+        @if (ChatState.VulnResults is null)
+        {
+            <p>No vulnerability scan has been run for this SBOM.</p>
+        }
+        else
+        {
+            <p>@_totalVulns total vulnerabilities — @_critCount critical, @_highCount high, @_medCount medium, @_lowCount low.</p>
+            @if (_totalVulns > 0)
+            {
+                <table class="print-table">
+                    <thead>
+                        <tr><th>Package</th><th>CVE / ID</th><th>Severity</th><th>CVSS</th><th>Fixed Version</th></tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var r in ChatState.VulnResults)
+                        {
+                            @foreach (var v in r.Vulnerabilities)
+                            {
+                                <tr>
+                                    <td>@r.PackageName@@@r.PackageVersion</td>
+                                    <td>@v.Id</td>
+                                    <td>@(v.Severity ?? "Unknown")</td>
+                                    <td>@(v.CvssScore?.ToString("F1") ?? "—")</td>
+                                    <td>@(v.FixedVersion ?? "—")</td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            }
+        }
+
+        <h2>License Compliance Summary</h2>
+        <p>
+            @_permissiveCount permissive · @_weakCopyleftCount weak copyleft ·
+            @_strongCopyleftCount strong copyleft · @_unknownLicenseCount unknown/unclear
+        </p>
+        @{
+            var flaggedLicenseRows = _componentRows.Where(r => r.Risk is LicenseRisk.StrongCopyleft or LicenseRisk.Unknown).OrderBy(r => r.Name).ToList();
+        }
+        @if (flaggedLicenseRows.Count == 0)
+        {
+            <p>No strong-copyleft or unrecognized licenses found.</p>
+        }
+        else
+        {
+            <table class="print-table">
+                <thead>
+                    <tr><th>Component</th><th>Version</th><th>License</th><th>Risk</th></tr>
+                </thead>
+                <tbody>
+                    @foreach (var r in flaggedLicenseRows)
+                    {
+                        <tr>
+                            <td>@r.Name</td>
+                            <td>@r.Version</td>
+                            <td>@(string.IsNullOrEmpty(r.License) ? "—" : r.License)</td>
+                            <td>@r.Risk</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+
+        <h2>License Distribution</h2>
+        @if (_licenseDist.Count == 0)
+        {
+            <p>No license data found.</p>
+        }
+        else
+        {
+            <table class="print-table">
+                <thead><tr><th>License</th><th>Components</th></tr></thead>
+                <tbody>
+                    @foreach (var kv in _licenseDist)
+                    {
+                        <tr><td>@kv.Key</td><td>@kv.Value</td></tr>
+                    }
+                </tbody>
+            </table>
+        }
+
+        <p class="print-disclaimer">
+            This report is generated automatically from SBOM metadata (CycloneDX or SPDX) and the OSV.dev vulnerability database.
+            License risk categories are derived from a curated license-identifier lookup and may not reflect a complete
+            or compatible license analysis (e.g. compound license expressions, custom license text). This report is
+            provided for informational purposes only, does not constitute legal advice, and should not be relied upon
+            as a substitute for review by qualified legal counsel.
+        </p>
     </div>
 }
 
@@ -133,6 +264,7 @@
     private int _totalVulns;
     private int _critCount, _highCount, _medCount, _lowCount;
     private Dictionary<string, int> _licenseDist = [];
+    private int _permissiveCount, _weakCopyleftCount, _strongCopyleftCount, _unknownLicenseCount;
 
     // Component data
     private List<ComponentRow> _componentRows = [];
@@ -150,10 +282,13 @@
     private string? _vulnSevFilter = null;
     private HashSet<string> _expandedVulns = [];
 
+    // Compliance tab state
+    private string       _complianceSearch    = "";
+    private LicenseRisk? _complianceRiskFilter = null;
+
     // Dynamic sidebar sections
     private Dictionary<string, DynSection> _dynamicSections = [];
 
-    private record ComponentRow(string Name, string Version, string Type, string License, string? Purl);
     private record DynSection(string Label, string Icon, int Count, JsonElement Element, SchemaNode? Schema);
 
     // ── Lifecycle ──────────────────────────────────────────────────────────────
@@ -181,11 +316,13 @@
 
     private void SetTab(string tab) { _activeTab = tab; }
 
+    private async Task ExportReport() => await JS.InvokeVoidAsync("sbomPrintReport");
+
     // ── Data derivation ────────────────────────────────────────────────────────
 
     private void BuildDerivedData()
     {
-        _componentRows = ExtractComponentRows();
+        _componentRows = ComponentRowExtractor.Extract(RootElement, SbomState.DetectedFormat);
         _componentCount = _componentRows.Count;
 
         var licGroups = _componentRows
@@ -195,6 +332,11 @@
             .ToList();
         _licenseCount = licGroups.Count;
         _licenseDist  = licGroups.Take(5).ToDictionary(g => g.Key, g => g.Count());
+
+        _permissiveCount     = _componentRows.Count(r => r.Risk == LicenseRisk.Permissive);
+        _weakCopyleftCount   = _componentRows.Count(r => r.Risk == LicenseRisk.WeakCopyleft);
+        _strongCopyleftCount = _componentRows.Count(r => r.Risk == LicenseRisk.StrongCopyleft);
+        _unknownLicenseCount = _componentRows.Count(r => r.Risk == LicenseRisk.Unknown);
 
         _generatedDate = ExtractGeneratedDate();
         BuildDynamicSections();
@@ -232,68 +374,6 @@
     }
 
     // ── JSON extraction ────────────────────────────────────────────────────────
-
-    private List<ComponentRow> ExtractComponentRows()
-    {
-        var rows = new List<ComponentRow>();
-        var format = SbomState.DetectedFormat;
-
-        if (format is SbomFormat.CycloneDX_1_6 or SbomFormat.CycloneDX_1_7)
-        {
-            if (!RootElement.TryGetProperty("components", out var comps) ||
-                comps.ValueKind != JsonValueKind.Array) return rows;
-
-            foreach (var comp in comps.EnumerateArray())
-            {
-                var name    = comp.TryGetProperty("name",    out var n) ? n.GetString() ?? "" : "";
-                var version = comp.TryGetProperty("version", out var v) ? v.GetString() ?? "" : "";
-                var type    = comp.TryGetProperty("type",    out var t) ? t.GetString() ?? "" : "";
-                var purl    = comp.TryGetProperty("purl",    out var p) ? p.GetString()      : null;
-                var license = "";
-                if (comp.TryGetProperty("licenses", out var lics) && lics.ValueKind == JsonValueKind.Array)
-                {
-                    var first = lics.EnumerateArray().FirstOrDefault();
-                    if (first.ValueKind == JsonValueKind.Object)
-                    {
-                        if (first.TryGetProperty("license", out var lic) && lic.TryGetProperty("id", out var lid))
-                            license = lid.GetString() ?? "";
-                        else if (first.TryGetProperty("expression", out var expr))
-                            license = expr.GetString() ?? "";
-                    }
-                }
-                if (!string.IsNullOrEmpty(name))
-                    rows.Add(new ComponentRow(name, version, type, license, purl));
-            }
-        }
-        else if (format is SbomFormat.SPDX_2_2)
-        {
-            if (!RootElement.TryGetProperty("packages", out var pkgs) ||
-                pkgs.ValueKind != JsonValueKind.Array) return rows;
-
-            foreach (var pkg in pkgs.EnumerateArray())
-            {
-                var name    = pkg.TryGetProperty("name",             out var n) ? n.GetString() ?? "" : "";
-                var version = pkg.TryGetProperty("versionInfo",      out var v) ? v.GetString() ?? "" : "";
-                var license = pkg.TryGetProperty("licenseConcluded", out var l) ? l.GetString() ?? "" : "";
-                if (license is "NOASSERTION" or "NONE") license = "";
-                string? purl = null;
-                if (pkg.TryGetProperty("externalRefs", out var refs) && refs.ValueKind == JsonValueKind.Array)
-                {
-                    foreach (var r in refs.EnumerateArray())
-                    {
-                        if (r.TryGetProperty("referenceCategory", out var cat) &&
-                            r.TryGetProperty("referenceLocator",  out var loc) &&
-                            cat.GetString() is "PACKAGE-MANAGER" or "PACKAGE_MANAGER")
-                        { purl = loc.GetString(); break; }
-                    }
-                }
-                if (!string.IsNullOrEmpty(name))
-                    rows.Add(new ComponentRow(name, version, "package", license, purl));
-            }
-        }
-
-        return rows;
-    }
 
     private string? ExtractGeneratedDate()
     {
@@ -386,13 +466,13 @@
     @<div class="content fadein">
         @* Stats grid *@
         <div class="stats-grid">
-            <div class="stat-card">
+            <div class="stat-card clickable" @onclick='() => SetTab("components")'>
                 <div class="stat-label">Components</div>
                 <div class="stat-value">@_componentCount</div>
                 <div class="stat-sub">in this SBOM</div>
                 <div class="stat-bar"><div class="stat-bar-fill" style="width:100%; background:var(--accent)"></div></div>
             </div>
-            <div class="stat-card">
+            <div class="stat-card clickable" @onclick='() => SetTab("vulns")'>
                 <div class="stat-label">Vulnerabilities</div>
                 <div class="stat-value" style="color:@(_critCount > 0 ? "var(--crit)" : _totalVulns > 0 ? "var(--high)" : "var(--text)")">
                     @if (ChatState.VulnResults is null && !ChatState.IsScanning)
@@ -414,7 +494,7 @@
                     <div class="stat-bar-fill" style="width:@(ChatState.VulnResults is not null ? $"{Math.Min(100, _totalVulns * 5)}%" : "0%"); background:var(--crit)"></div>
                 </div>
             </div>
-            <div class="stat-card">
+            <div class="stat-card clickable" @onclick='() => SetTab("compliance")'>
                 <div class="stat-label">Licenses</div>
                 <div class="stat-value">@_licenseCount</div>
                 <div class="stat-sub">unique license types</div>
@@ -440,7 +520,7 @@
 
         @* Severity + License row *@
         <div class="vuln-row">
-            <div class="vuln-summary">
+            <div class="vuln-summary clickable" @onclick='() => SetTab("vulns")'>
                 <div class="card-title">Vulnerability Severity</div>
                 @if (ChatState.VulnResults is null)
                 {
@@ -476,7 +556,7 @@
                     </div>
                 }
             </div>
-            <div class="license-summary">
+            <div class="license-summary clickable" @onclick='() => SetTab("compliance")'>
                 <div class="card-title">License Distribution</div>
                 @if (_licenseDist.Count == 0)
                 {
@@ -595,6 +675,121 @@
                         }
                     </tbody>
                 </table>
+            </div>
+        </div>;
+    }
+
+    private RenderFragment RenderComplianceTab()
+    {
+        var q = _complianceSearch.ToLowerInvariant();
+        var flagged = _componentRows.Where(r => r.Risk is LicenseRisk.StrongCopyleft or LicenseRisk.Unknown).AsEnumerable();
+
+        if (!string.IsNullOrEmpty(q))
+            flagged = flagged.Where(r =>
+                r.Name.Contains(q, StringComparison.OrdinalIgnoreCase) ||
+                r.License.Contains(q, StringComparison.OrdinalIgnoreCase));
+
+        if (_complianceRiskFilter is not null)
+            flagged = flagged.Where(r => r.Risk == _complianceRiskFilter);
+
+        var list = flagged.OrderBy(r => r.Name).ToList();
+
+        return @<div style="display:flex; flex-direction:column; height:100%; overflow:hidden;" class="fadein">
+            <div class="toolbar">
+                <div class="search-box">
+                    <span class="search-icon">⌕</span>
+                    <input placeholder="Search flagged components…" value="@_complianceSearch"
+                           @oninput="e => _complianceSearch = e.Value?.ToString() ?? string.Empty" />
+                </div>
+                <button class="filter-btn @(_complianceRiskFilter == LicenseRisk.StrongCopyleft ? "active" : "")"
+                        @onclick="() => _complianceRiskFilter = _complianceRiskFilter == LicenseRisk.StrongCopyleft ? null : LicenseRisk.StrongCopyleft">
+                    STRONG COPYLEFT
+                </button>
+                <button class="filter-btn @(_complianceRiskFilter == LicenseRisk.Unknown ? "active" : "")"
+                        @onclick="() => _complianceRiskFilter = _complianceRiskFilter == LicenseRisk.Unknown ? null : LicenseRisk.Unknown">
+                    UNKNOWN
+                </button>
+                <div class="toolbar-right">
+                    <span class="count-label">@list.Count flagged of @_componentCount components</span>
+                </div>
+            </div>
+
+            <div class="content" style="overflow-y:auto;">
+                <div class="stats-grid" style="margin-bottom:20px;">
+                    <div class="stat-card">
+                        <div class="stat-label">Permissive</div>
+                        <div class="stat-value" style="color:var(--low)">@_permissiveCount</div>
+                        <div class="stat-sub">MIT, Apache-2.0, BSD…</div>
+                        <div class="stat-bar"><div class="stat-bar-fill" style="width:@StatPct(_permissiveCount)%; background:var(--low)"></div></div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Weak Copyleft</div>
+                        <div class="stat-value" style="color:var(--med)">@_weakCopyleftCount</div>
+                        <div class="stat-sub">LGPL, MPL, EPL…</div>
+                        <div class="stat-bar"><div class="stat-bar-fill" style="width:@StatPct(_weakCopyleftCount)%; background:var(--med)"></div></div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Strong Copyleft</div>
+                        <div class="stat-value" style="color:var(--crit)">@_strongCopyleftCount</div>
+                        <div class="stat-sub">GPL, AGPL, SSPL…</div>
+                        <div class="stat-bar"><div class="stat-bar-fill" style="width:@StatPct(_strongCopyleftCount)%; background:var(--crit)"></div></div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Unknown</div>
+                        <div class="stat-value" style="color:var(--text-dimmer)">@_unknownLicenseCount</div>
+                        <div class="stat-sub">unclear or custom license</div>
+                        <div class="stat-bar"><div class="stat-bar-fill" style="width:@StatPct(_unknownLicenseCount)%; background:var(--text-dimmer)"></div></div>
+                    </div>
+                </div>
+
+                <div class="compliance-disclaimer">
+                    ⓘ License risk categories are derived from a curated license-identifier lookup (works with both CycloneDX
+                    and SPDX SBOMs) and are provided for informational purposes only. This is not legal advice — consult qualified legal counsel for compliance decisions.
+                </div>
+
+                @if (list.Count == 0)
+                {
+                    <div class="empty-state">
+                        <div class="empty-state-icon" style="color:var(--low)">✓</div>
+                        <div class="empty-state-title" style="color:var(--low)">No risky or unclear licenses found</div>
+                        <div>All scanned components use permissive or weak-copyleft licenses.</div>
+                    </div>
+                }
+                else
+                {
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Version</th>
+                                <th>License</th>
+                                <th>Risk</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var r in list)
+                            {
+                                <tr>
+                                    <td>
+                                        <div class="td-name">@r.Name</div>
+                                        @if (!string.IsNullOrEmpty(r.Purl))
+                                        {
+                                            <div class="td-purl" title="@r.Purl">@r.Purl</div>
+                                        }
+                                    </td>
+                                    <td><span class="td-ver">@r.Version</span></td>
+                                    <td>
+                                        @if (!string.IsNullOrEmpty(r.License))
+                                        { <span class="license-badge">@r.License</span> }
+                                        else
+                                        { <span style="color:var(--text-dimmer); font-size:11px;">—</span> }
+                                    </td>
+                                    <td>@RiskBadge(r.Risk)</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
             </div>
         </div>;
     }
@@ -763,6 +958,21 @@
         };
         return @<span class="sev-badge @cls">@(sev ?? "NONE")</span>;
     }
+
+    private static RenderFragment RiskBadge(LicenseRisk risk)
+    {
+        var (cls, label) = risk switch
+        {
+            LicenseRisk.Permissive     => ("risk-permissive", "PERMISSIVE"),
+            LicenseRisk.WeakCopyleft   => ("risk-weak", "WEAK COPYLEFT"),
+            LicenseRisk.StrongCopyleft => ("risk-strong", "STRONG COPYLEFT"),
+            LicenseRisk.Proprietary    => ("risk-strong", "PROPRIETARY"),
+            _                          => ("risk-unknown", "UNKNOWN"),
+        };
+        return @<span class="license-risk-badge @cls">@label</span>;
+    }
+
+    private double StatPct(int count) => _componentCount > 0 ? Math.Round((double)count / _componentCount * 100, 1) : 0;
 
     private static string ScoreColor(double s) =>
         s >= 9 ? "var(--crit)" : s >= 7 ? "var(--high)" : s >= 4 ? "var(--med)" : "var(--low)";

--- a/src/SBOMViewer.Blazor/Components/UploadFile.razor
+++ b/src/SBOMViewer.Blazor/Components/UploadFile.razor
@@ -19,7 +19,7 @@
          @ondrop="OnDrop">
 
         <!-- InputFile covers entire dropzone — handles both click-to-browse and drag-and-drop -->
-        <InputFile style="position:absolute; inset:0; opacity:0; cursor:pointer; z-index:2; width:100%; height:100%;"
+        <InputFile style="position:absolute; inset:0; opacity:0; cursor:pointer; z-index:2; width:100%; height:100%; outline:none;"
                    accept=".json"
                    OnChange="OnFileChanged" />
 

--- a/src/SBOMViewer.Blazor/Models/ComponentRow.cs
+++ b/src/SBOMViewer.Blazor/Models/ComponentRow.cs
@@ -1,0 +1,3 @@
+namespace SBOMViewer.Blazor.Models;
+
+public record ComponentRow(string Name, string Version, string Type, string License, string? Purl, LicenseRisk Risk);

--- a/src/SBOMViewer.Blazor/Models/LicenseRisk.cs
+++ b/src/SBOMViewer.Blazor/Models/LicenseRisk.cs
@@ -1,0 +1,10 @@
+namespace SBOMViewer.Blazor.Models;
+
+public enum LicenseRisk
+{
+    Permissive,
+    WeakCopyleft,
+    StrongCopyleft,
+    Proprietary,
+    Unknown
+}

--- a/src/SBOMViewer.Blazor/Pages/Home.razor
+++ b/src/SBOMViewer.Blazor/Pages/Home.razor
@@ -28,7 +28,7 @@
 
             @if (SbomState.Document is not null)
             {
-                <button class="btn-ghost" @onclick="NewFile">← New file</button>
+                <button class="btn-primary" @onclick="NewFile">← New file</button>
             }
         </div>
     </nav>

--- a/src/SBOMViewer.Blazor/Services/ComponentRowExtractor.cs
+++ b/src/SBOMViewer.Blazor/Services/ComponentRowExtractor.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using SBOMViewer.Blazor.Models;
+
+namespace SBOMViewer.Blazor.Services;
+
+public static class ComponentRowExtractor
+{
+    public static List<ComponentRow> Extract(JsonElement root, SbomFormat? format)
+    {
+        return format switch
+        {
+            SbomFormat.CycloneDX_1_6 or SbomFormat.CycloneDX_1_7 => ExtractCycloneDx(root),
+            SbomFormat.SPDX_2_2 => ExtractSpdx(root),
+            _ => []
+        };
+    }
+
+    private static List<ComponentRow> ExtractCycloneDx(JsonElement root)
+    {
+        var rows = new List<ComponentRow>();
+
+        if (!root.TryGetProperty("components", out var comps) ||
+            comps.ValueKind != JsonValueKind.Array) return rows;
+
+        foreach (var comp in comps.EnumerateArray())
+        {
+            var name    = comp.TryGetProperty("name",    out var n) ? n.GetString() ?? "" : "";
+            var version = comp.TryGetProperty("version", out var v) ? v.GetString() ?? "" : "";
+            var type    = comp.TryGetProperty("type",    out var t) ? t.GetString() ?? "" : "";
+            var purl    = comp.TryGetProperty("purl",    out var p) ? p.GetString()      : null;
+            var license = "";
+            if (comp.TryGetProperty("licenses", out var lics) && lics.ValueKind == JsonValueKind.Array)
+            {
+                var first = lics.EnumerateArray().FirstOrDefault();
+                if (first.ValueKind == JsonValueKind.Object)
+                {
+                    if (first.TryGetProperty("license", out var lic) && lic.TryGetProperty("id", out var lid))
+                        license = lid.GetString() ?? "";
+                    else if (first.TryGetProperty("license", out var licName) && licName.TryGetProperty("name", out var lname))
+                        license = lname.GetString() ?? "";
+                    else if (first.TryGetProperty("expression", out var expr))
+                        license = expr.GetString() ?? "";
+                }
+            }
+            if (!string.IsNullOrEmpty(name))
+                rows.Add(new ComponentRow(name, version, type, license, purl, LicenseClassifier.Classify(license)));
+        }
+
+        return rows;
+    }
+
+    private static List<ComponentRow> ExtractSpdx(JsonElement root)
+    {
+        var rows = new List<ComponentRow>();
+
+        if (!root.TryGetProperty("packages", out var pkgs) ||
+            pkgs.ValueKind != JsonValueKind.Array) return rows;
+
+        foreach (var pkg in pkgs.EnumerateArray())
+        {
+            var name    = pkg.TryGetProperty("name",             out var n) ? n.GetString() ?? "" : "";
+            var version = pkg.TryGetProperty("versionInfo",      out var v) ? v.GetString() ?? "" : "";
+            var license = pkg.TryGetProperty("licenseConcluded", out var l) ? l.GetString() ?? "" : "";
+            if (license is "NOASSERTION" or "NONE") license = "";
+            string? purl = null;
+            if (pkg.TryGetProperty("externalRefs", out var refs) && refs.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var r in refs.EnumerateArray())
+                {
+                    if (r.TryGetProperty("referenceCategory", out var cat) &&
+                        r.TryGetProperty("referenceLocator",  out var loc) &&
+                        cat.GetString() is "PACKAGE-MANAGER" or "PACKAGE_MANAGER")
+                    { purl = loc.GetString(); break; }
+                }
+            }
+            if (!string.IsNullOrEmpty(name))
+                rows.Add(new ComponentRow(name, version, "package", license, purl, LicenseClassifier.Classify(license)));
+        }
+
+        return rows;
+    }
+}

--- a/src/SBOMViewer.Blazor/Services/LicenseClassifier.cs
+++ b/src/SBOMViewer.Blazor/Services/LicenseClassifier.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+using SBOMViewer.Blazor.Models;
+
+namespace SBOMViewer.Blazor.Services;
+
+public static partial class LicenseClassifier
+{
+    private static readonly Dictionary<string, LicenseRisk> Map = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Permissive
+        ["MIT"] = LicenseRisk.Permissive,
+        ["MIT-0"] = LicenseRisk.Permissive,
+        ["Apache-1.1"] = LicenseRisk.Permissive,
+        ["Apache-2.0"] = LicenseRisk.Permissive,
+        ["BSD-2-Clause"] = LicenseRisk.Permissive,
+        ["BSD-3-Clause"] = LicenseRisk.Permissive,
+        ["BSD-3-Clause-Clear"] = LicenseRisk.Permissive,
+        ["BSD-4-Clause"] = LicenseRisk.Permissive,
+        ["0BSD"] = LicenseRisk.Permissive,
+        ["ISC"] = LicenseRisk.Permissive,
+        ["Unlicense"] = LicenseRisk.Permissive,
+        ["PostgreSQL"] = LicenseRisk.Permissive,
+        ["Python-2.0"] = LicenseRisk.Permissive,
+        ["Zlib"] = LicenseRisk.Permissive,
+        ["libpng-2.0"] = LicenseRisk.Permissive,
+        ["X11"] = LicenseRisk.Permissive,
+        ["WTFPL"] = LicenseRisk.Permissive,
+        ["CC0-1.0"] = LicenseRisk.Permissive,
+        ["BlueOak-1.0.0"] = LicenseRisk.Permissive,
+        ["Artistic-2.0"] = LicenseRisk.Permissive,
+        ["NCSA"] = LicenseRisk.Permissive,
+        ["Boost-1.0"] = LicenseRisk.Permissive,
+        ["OpenSSL"] = LicenseRisk.Permissive,
+        ["Vim"] = LicenseRisk.Permissive,
+        ["CC-BY-3.0"] = LicenseRisk.Permissive,
+        ["CC-BY-4.0"] = LicenseRisk.Permissive,
+
+        // Weak copyleft
+        ["LGPL-2.0"] = LicenseRisk.WeakCopyleft,
+        ["LGPL-2.1"] = LicenseRisk.WeakCopyleft,
+        ["LGPL-3.0"] = LicenseRisk.WeakCopyleft,
+        ["MPL-1.0"] = LicenseRisk.WeakCopyleft,
+        ["MPL-1.1"] = LicenseRisk.WeakCopyleft,
+        ["MPL-2.0"] = LicenseRisk.WeakCopyleft,
+        ["EPL-1.0"] = LicenseRisk.WeakCopyleft,
+        ["EPL-2.0"] = LicenseRisk.WeakCopyleft,
+        ["CDDL-1.0"] = LicenseRisk.WeakCopyleft,
+        ["CDDL-1.1"] = LicenseRisk.WeakCopyleft,
+        ["CPL-1.0"] = LicenseRisk.WeakCopyleft,
+
+        // Strong copyleft
+        ["GPL-1.0"] = LicenseRisk.StrongCopyleft,
+        ["GPL-2.0"] = LicenseRisk.StrongCopyleft,
+        ["GPL-3.0"] = LicenseRisk.StrongCopyleft,
+        ["AGPL-1.0"] = LicenseRisk.StrongCopyleft,
+        ["AGPL-3.0"] = LicenseRisk.StrongCopyleft,
+        ["SSPL-1.0"] = LicenseRisk.StrongCopyleft,
+        ["OSL-3.0"] = LicenseRisk.StrongCopyleft,
+        ["EUPL-1.1"] = LicenseRisk.StrongCopyleft,
+        ["EUPL-1.2"] = LicenseRisk.StrongCopyleft,
+    };
+
+    public static LicenseRisk Classify(string? license)
+    {
+        if (string.IsNullOrWhiteSpace(license)) return LicenseRisk.Unknown;
+
+        var normalized = Normalize(license);
+        return Map.TryGetValue(normalized, out var risk) ? risk : LicenseRisk.Unknown;
+    }
+
+    private static string Normalize(string license)
+    {
+        var s = license.Trim();
+        if (s.EndsWith('+')) s = s[..^1];
+        return SuffixRegex().Replace(s, "");
+    }
+
+    [GeneratedRegex(@"-(only|or-later)$", RegexOptions.IgnoreCase)]
+    private static partial Regex SuffixRegex();
+}

--- a/src/SBOMViewer.Blazor/wwwroot/css/app.css
+++ b/src/SBOMViewer.Blazor/wwwroot/css/app.css
@@ -93,6 +93,12 @@ body {
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-dimmer); }
 
+/* Replace the browser's default focus rectangle with a theme-consistent ring */
+:focus { outline: none; }
+:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px;
+}
+
 /* ── App shell ─────────────────────────────────────────────────────────────── */
 .app { display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
 
@@ -195,6 +201,7 @@ body {
     linear-gradient(var(--border) 1px, transparent 1px),
     linear-gradient(90deg, var(--border) 1px, transparent 1px);
   background-size: 40px 40px;
+  -webkit-mask-image: radial-gradient(ellipse 80% 70% at 50% 50%, black 20%, transparent 100%);
   mask-image: radial-gradient(ellipse 80% 70% at 50% 50%, black 20%, transparent 100%);
   opacity: 0.6;
   pointer-events: none;
@@ -214,7 +221,7 @@ body {
   display: flex; flex-direction: column; align-items: center; gap: 16px;
   cursor: pointer; transition: all 0.2s; overflow: hidden;
 }
-.dropzone:hover, .dropzone.dragover {
+.dropzone:hover, .dropzone.dragover, .dropzone:has(input:focus-visible) {
   border-color: var(--accent); background: var(--accent-glow);
   box-shadow: 0 0 48px var(--accent-glow);
 }
@@ -334,6 +341,10 @@ body {
   padding: 18px 16px; transition: border-color 0.15s;
 }
 .stat-card:hover { border-color: var(--text-dimmer); }
+.clickable { cursor: pointer; }
+.stat-card.clickable:hover, .vuln-summary.clickable:hover, .license-summary.clickable:hover {
+  border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent-glow);
+}
 .stat-label { font-size: 0.9375rem; color: var(--text-dimmer); margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
 .stat-value { font-size: 2.25rem; font-weight: 700; letter-spacing: -0.04em; line-height: 1; margin-bottom: 6px; color: var(--text); }
 .stat-sub { font-size: 0.75rem; color: var(--text-dimmer); }
@@ -394,6 +405,17 @@ body {
 .sev-badge.low  { background: oklch(68% 0.18 150 / 0.15); color: var(--low);  border: 1px solid oklch(68% 0.18 150 / 0.35); }
 .sev-badge.none { background: var(--bg3); color: var(--text-dimmer); border: 1px solid var(--border); }
 
+/* ── License risk badges ───────────────────────────────────────────────────── */
+.license-risk-badge {
+  display: inline-flex; align-items: center;
+  padding: 3px 9px; border-radius: 5px; font-size: 0.6875rem; font-weight: 700;
+  font-family: var(--mono); letter-spacing: 0.04em;
+}
+.license-risk-badge.risk-permissive { background: oklch(68% 0.18 150 / 0.15); color: var(--low);  border: 1px solid oklch(68% 0.18 150 / 0.35); }
+.license-risk-badge.risk-weak       { background: oklch(78% 0.18 80  / 0.15); color: var(--med);  border: 1px solid oklch(78% 0.18 80  / 0.35); }
+.license-risk-badge.risk-strong     { background: oklch(60% 0.22 20  / 0.15); color: var(--crit); border: 1px solid oklch(60% 0.22 20  / 0.35); }
+.license-risk-badge.risk-unknown    { background: var(--bg3); color: var(--text-dimmer); border: 1px solid var(--border); }
+
 /* ── Vuln cards ────────────────────────────────────────────────────────────── */
 .vuln-list { display: flex; flex-direction: column; gap: 10px; }
 .vuln-card {
@@ -447,6 +469,12 @@ body {
   border-radius: 7px; font-size: 0.8125rem; color: var(--med);
 }
 
+.compliance-disclaimer {
+  padding: 9px 14px; margin-bottom: 16px;
+  background: var(--bg3); border: 1px solid var(--border);
+  border-radius: 7px; font-size: 0.75rem; color: var(--text-dimmer); line-height: 1.5;
+}
+
 /* ── Dynamic section ───────────────────────────────────────────────────────── */
 .info-container { display: flex; flex-direction: column; gap: 0.4rem; }
 
@@ -486,3 +514,26 @@ body {
   color: var(--crit); border-radius: var(--radius); border: 1px solid oklch(60% 0.22 20 / 0.25);
 }
 .blazor-error-boundary::before { content: "Error: "; font-weight: 600; }
+
+/* ── Printable report ──────────────────────────────────────────────────────── */
+.print-report { display: none; }
+
+@media print {
+  body * { visibility: hidden; }
+  .print-report, .print-report * { visibility: visible; }
+  .print-report {
+    display: block; position: absolute; top: 0; left: 0; width: 100%;
+    background: #fff; color: #1a1a1a; font-family: var(--sans, sans-serif); padding: 24px;
+  }
+  .print-report h1 { font-size: 1.5rem; margin-bottom: 4px; }
+  .print-report h2 { font-size: 1.125rem; margin: 24px 0 8px; page-break-after: avoid; }
+  .print-report p { font-size: 0.875rem; margin: 4px 0 12px; }
+  .print-meta { font-size: 0.8125rem; margin-bottom: 16px; display: flex; flex-direction: column; gap: 2px; }
+  .print-table { width: 100%; border-collapse: collapse; font-size: 0.8125rem; margin-bottom: 12px; page-break-inside: avoid; }
+  .print-table th, .print-table td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
+  .print-table th { background: #f0f0f0; }
+  .print-disclaimer {
+    margin-top: 28px; padding-top: 12px; border-top: 1px solid #ccc;
+    font-size: 0.6875rem; color: #666; line-height: 1.5;
+  }
+}

--- a/src/SBOMViewer.Blazor/wwwroot/index.html
+++ b/src/SBOMViewer.Blazor/wwwroot/index.html
@@ -116,6 +116,7 @@
       document.body.removeChild(a);
       setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
     };
+    window.sbomPrintReport = function () { window.print(); };
   </script>
 
   <script src="_framework/blazor.webassembly.js"></script>

--- a/tests/SBOMViewer.Blazor.Tests/Services/ComponentRowExtractorTests.cs
+++ b/tests/SBOMViewer.Blazor.Tests/Services/ComponentRowExtractorTests.cs
@@ -1,0 +1,214 @@
+using System.Text.Json;
+using FluentAssertions;
+using SBOMViewer.Blazor.Models;
+using SBOMViewer.Blazor.Services;
+
+namespace SBOMViewer.Blazor.Tests.Services;
+
+public class ComponentRowExtractorTests
+{
+    // ─── CycloneDX ──────────────────────────────────────────
+
+    [Fact]
+    public void Extract_CycloneDX_LicenseId_UsesIdAndClassifies()
+    {
+        var json = """
+            {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "components": [
+                    { "name": "Newtonsoft.Json", "version": "13.0.3", "type": "library",
+                      "purl": "pkg:nuget/Newtonsoft.Json@13.0.3",
+                      "licenses": [ { "license": { "id": "MIT" } } ] }
+                ]
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.CycloneDX_1_6);
+
+        result.Should().HaveCount(1);
+        result[0].Name.Should().Be("Newtonsoft.Json");
+        result[0].License.Should().Be("MIT");
+        result[0].Risk.Should().Be(LicenseRisk.Permissive);
+    }
+
+    [Fact]
+    public void Extract_CycloneDX_LicenseNameFallback_UsedWhenNoId()
+    {
+        var json = """
+            {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.7",
+                "components": [
+                    { "name": "Npgsql", "version": "8.0.0", "type": "library",
+                      "licenses": [ { "license": { "name": "PostgreSQL License" } } ] }
+                ]
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.CycloneDX_1_7);
+
+        result.Should().HaveCount(1);
+        result[0].License.Should().Be("PostgreSQL License");
+    }
+
+    [Fact]
+    public void Extract_CycloneDX_LicenseExpressionFallback_UsedWhenNoLicenseObject()
+    {
+        var json = """
+            {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "components": [
+                    { "name": "dual-licensed-lib", "version": "1.0.0", "type": "library",
+                      "licenses": [ { "expression": "MIT OR Apache-2.0" } ] }
+                ]
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.CycloneDX_1_6);
+
+        result.Should().HaveCount(1);
+        result[0].License.Should().Be("MIT OR Apache-2.0");
+        result[0].Risk.Should().Be(LicenseRisk.Unknown);
+    }
+
+    [Fact]
+    public void Extract_CycloneDX_NoLicenses_EmptyLicenseAndUnknownRisk()
+    {
+        var json = """
+            {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "components": [
+                    { "name": "no-license-lib", "version": "1.0.0", "type": "library" }
+                ]
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.CycloneDX_1_6);
+
+        result.Should().HaveCount(1);
+        result[0].License.Should().BeEmpty();
+        result[0].Risk.Should().Be(LicenseRisk.Unknown);
+    }
+
+    [Fact]
+    public void Extract_CycloneDX_StrongCopyleftLicense_ClassifiesAsStrongCopyleft()
+    {
+        var json = """
+            {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "components": [
+                    { "name": "gpl-lib", "version": "1.0.0", "type": "library",
+                      "licenses": [ { "license": { "id": "GPL-3.0-only" } } ] }
+                ]
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.CycloneDX_1_6);
+
+        result[0].Risk.Should().Be(LicenseRisk.StrongCopyleft);
+    }
+
+    [Fact]
+    public void Extract_CycloneDX_NoComponents_ReturnsEmpty()
+    {
+        var json = """
+            {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "metadata": {}
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.CycloneDX_1_6);
+
+        result.Should().BeEmpty();
+    }
+
+    // ─── SPDX ──────────────────────────────────────────
+
+    [Fact]
+    public void Extract_Spdx_LicenseConcluded_UsedAndClassified()
+    {
+        var json = """
+            {
+                "spdxVersion": "SPDX-2.2",
+                "packages": [
+                    {
+                        "name": "Microsoft.EntityFrameworkCore",
+                        "versionInfo": "8.0.0",
+                        "licenseConcluded": "MIT",
+                        "externalRefs": [
+                            { "referenceCategory": "PACKAGE-MANAGER", "referenceLocator": "pkg:nuget/Microsoft.EntityFrameworkCore@8.0.0" }
+                        ]
+                    }
+                ]
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.SPDX_2_2);
+
+        result.Should().HaveCount(1);
+        result[0].License.Should().Be("MIT");
+        result[0].Risk.Should().Be(LicenseRisk.Permissive);
+        result[0].Purl.Should().Be("pkg:nuget/Microsoft.EntityFrameworkCore@8.0.0");
+    }
+
+    [Theory]
+    [InlineData("NOASSERTION")]
+    [InlineData("NONE")]
+    public void Extract_Spdx_NoAssertionOrNone_TreatedAsEmpty(string licenseConcluded)
+    {
+        var json = $$"""
+            {
+                "spdxVersion": "SPDX-2.2",
+                "packages": [
+                    { "name": "PackageA", "versionInfo": "1.0.0", "licenseConcluded": "{{licenseConcluded}}" }
+                ]
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.SPDX_2_2);
+
+        result.Should().HaveCount(1);
+        result[0].License.Should().BeEmpty();
+        result[0].Risk.Should().Be(LicenseRisk.Unknown);
+    }
+
+    [Fact]
+    public void Extract_Spdx_NoPackages_ReturnsEmpty()
+    {
+        var json = """
+            {
+                "spdxVersion": "SPDX-2.2",
+                "name": "Test SBOM"
+            }
+            """;
+        using var doc = JsonDocument.Parse(json);
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, SbomFormat.SPDX_2_2);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Extract_NullFormat_ReturnsEmpty()
+    {
+        using var doc = JsonDocument.Parse("""{ "components": [] }""");
+
+        var result = ComponentRowExtractor.Extract(doc.RootElement, null);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/SBOMViewer.Blazor.Tests/Services/LicenseClassifierTests.cs
+++ b/tests/SBOMViewer.Blazor.Tests/Services/LicenseClassifierTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using SBOMViewer.Blazor.Models;
+using SBOMViewer.Blazor.Services;
+
+namespace SBOMViewer.Blazor.Tests.Services;
+
+public class LicenseClassifierTests
+{
+    [Theory]
+    [InlineData("MIT")]
+    [InlineData("Apache-2.0")]
+    [InlineData("BSD-3-Clause")]
+    [InlineData("ISC")]
+    [InlineData("0BSD")]
+    [InlineData("Unlicense")]
+    [InlineData("PostgreSQL")]
+    [InlineData("Zlib")]
+    public void Classify_PermissiveLicenses_ReturnsPermissive(string license)
+    {
+        LicenseClassifier.Classify(license).Should().Be(LicenseRisk.Permissive);
+    }
+
+    [Theory]
+    [InlineData("LGPL-2.1")]
+    [InlineData("LGPL-3.0")]
+    [InlineData("MPL-2.0")]
+    [InlineData("EPL-2.0")]
+    [InlineData("CDDL-1.1")]
+    public void Classify_WeakCopyleftLicenses_ReturnsWeakCopyleft(string license)
+    {
+        LicenseClassifier.Classify(license).Should().Be(LicenseRisk.WeakCopyleft);
+    }
+
+    [Theory]
+    [InlineData("GPL-2.0")]
+    [InlineData("GPL-3.0")]
+    [InlineData("AGPL-3.0")]
+    [InlineData("SSPL-1.0")]
+    public void Classify_StrongCopyleftLicenses_ReturnsStrongCopyleft(string license)
+    {
+        LicenseClassifier.Classify(license).Should().Be(LicenseRisk.StrongCopyleft);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("NOASSERTION")]
+    [InlineData("PostgreSQL License")]
+    [InlineData("Custom-Internal-License")]
+    public void Classify_UnknownOrEmptyLicenses_ReturnsUnknown(string? license)
+    {
+        LicenseClassifier.Classify(license).Should().Be(LicenseRisk.Unknown);
+    }
+
+    [Theory]
+    [InlineData("mit")]
+    [InlineData("Mit")]
+    [InlineData("APACHE-2.0")]
+    public void Classify_IsCaseInsensitive(string license)
+    {
+        LicenseClassifier.Classify(license).Should().NotBe(LicenseRisk.Unknown);
+    }
+
+    [Theory]
+    [InlineData("GPL-2.0-only", LicenseRisk.StrongCopyleft)]
+    [InlineData("GPL-3.0-or-later", LicenseRisk.StrongCopyleft)]
+    [InlineData("LGPL-2.1-only", LicenseRisk.WeakCopyleft)]
+    [InlineData("GPL-2.0+", LicenseRisk.StrongCopyleft)]
+    public void Classify_StripsSpdxSuffixesBeforeMatching(string license, LicenseRisk expected)
+    {
+        LicenseClassifier.Classify(license).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Adds a Compliance tab that buckets component licenses (permissive/weak-copyleft/ strong-copyleft/unknown) via a curated identifier lookup, plus a browser print-to-PDF report combining vulnerability and license findings. Also extracts component/license parsing out of DynamicSbomViewer into a testable ComponentRowExtractor service, and fixes two UI polish issues found along the way (upload-grid mask rendering as a hard rectangle, native focus outline clashing with the dark theme).